### PR TITLE
Add Makefile for variables_and_data_types build

### DIFF
--- a/variables_and_data_types/Makefile
+++ b/variables_and_data_types/Makefile
@@ -1,0 +1,33 @@
+CC := gcc
+BUILD_DIR := build
+OBJ_DIR := $(BUILD_DIR)/obj
+TARGET := $(BUILD_DIR)/variables_and_data_types.exe
+
+SRCS_RAW := $(shell find . -name '*.c')
+SRCS := $(patsubst ./%,%,$(SRCS_RAW))
+OBJS := $(SRCS:%.c=$(OBJ_DIR)/%.o)
+
+INCLUDE_DIRS := . \
+    components \
+    components/drivers \
+    components/sensors \
+    components/utils \
+    modes
+
+CPPFLAGS := $(addprefix -I,$(INCLUDE_DIRS))
+CFLAGS ?= -Wall -Wextra -std=c11
+
+.PHONY: all clean
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	@mkdir -p $(dir $@)
+	$(CC) $(LDFLAGS) $^ -o $@
+
+$(OBJ_DIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -rf $(BUILD_DIR)


### PR DESCRIPTION
## Summary
- add a Makefile for the variables_and_data_types project that discovers sources automatically
- configure include directories and build rules to emit variables_and_data_types.exe inside the build directory

## Testing
- make *(fails: components/pumps/pump.c:3:10: fatal error: humidity/humidity.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68d54d05811c8333935024946af0cad4